### PR TITLE
Apply changes from fork: vutdang/Unity-File-Debug

### DIFF
--- a/Assets/UnityFileDebug/Lib/Logger/Scripts/DebugWrapper.cs
+++ b/Assets/UnityFileDebug/Lib/Logger/Scripts/DebugWrapper.cs
@@ -36,6 +36,7 @@ public static class Debug
     #region Helper
     public static void Break() { UnityEngine.Debug.Break(); }
     public static void ClearDeveloperConsole() { UnityEngine.Debug.ClearDeveloperConsole(); }
+    public static bool isDebugBuild { get { return UnityEngine.Debug.isDebugBuild; } }
     #endregion
 
     #region Draw

--- a/Assets/UnityFileDebug/Lib/Logger/Scripts/UnityFileDebug.cs
+++ b/Assets/UnityFileDebug/Lib/Logger/Scripts/UnityFileDebug.cs
@@ -115,8 +115,16 @@ namespace SSS
                 else
                 {
                     int end = logString.IndexOf("]");
-                    output.t = logString.Substring(1, end - 1);
-                    output.l = logString.Substring(end + 2);
+                    if (end > 1)
+                    {
+                        output.t = logString.Substring(1, end - 1);
+                        output.l = logString.Substring(end + 2);
+                    }
+                    else
+                    {
+                        output.t = type.ToString();
+                        output.l = logString;
+                    }
                 }
 
                 output.s = stackTrace;


### PR DESCRIPTION
I suspect ca98889 should solve the issues being experienced in #7 and #8 

- Add `isDebugBuild` to `DebugWrapper.cs`
- Fix out of range issue with substring in `UnityFileDebug.cs`

Thanks @vutdang